### PR TITLE
Using wrapping_shr to suppress 'attempt to shift right with overflow' error  to a bug on RaspberryPi (ARM32v7)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,8 @@ impl Hash {
         let r = if self.r < 56 { 64 } else { 128 };
         let bits = self.len * 8;
         for i in 0..8 {
-            padded[r - 8 + i] = (bits >> (56 - i * 8)) as u8;
+            padded[r - 8 + i] = (bits.wrapping_shr((56 - i * 8) as u32)) as u8;
+            //padded[r - 8 + i] = (bits >> (56 - i * 8)) as u8;
         }
         self.state.blocks(&padded[..r]);
         let mut out = [0u8; 32];


### PR DESCRIPTION
The bug won't happen on my Mac (x86 -64) but happened on my RaspberryPi ARM32v7. 
I did some research found using wrapping_shr can suppress this error.
so I try to make some changes and tested work on my RaspberryPi.  It won't hurt on X86 either.

So I send this pull request hoping it can help other developers on ARM.

There would be some other >> caused bugs in the code base, I did not fix them all before I get confirmation from the owner. So please let me know if my fix makes sense so I can help more.