### PR TITLE
Add opt_size feature for embedded environments.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ digest = { version = "0.9", optional = true }
 
 [features]
 default = []
+opt_size = []
 traits = ["digest"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A small, self-contained SHA256 and HMAC-SHA256 implementation in Rust.
 Optional features:
 
 * `traits`: enable support for the `Digest` trait from the `digest` crate.
+* `opt_size`: enable size optimizations. Based on benchmarks, the `.text`
+  section size is reduced by 75%, at the cost of approximately 16% performance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,8 @@ impl W {
         x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn M(&mut self, a: usize, b: usize, c: usize, d: usize) {
         let w = &mut self.0;
         w[a] = w[a]
@@ -99,7 +100,8 @@ impl W {
         self.M(15, (15 + 14) & 15, (15 + 9) & 15, (15 + 1) & 15);
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn F(&mut self, state: &mut State, i: usize, k: u32) {
         let t = &mut state.0;
         t[(16 - i + 7) & 7] = t[(16 - i + 7) & 7]
@@ -306,7 +308,7 @@ impl HMAC {
         ih.update(input);
 
         let mut oh = Hash::new();
-        let mut padded = [0x5c; 64];
+        padded = [0x5c; 64];
         for (p, &k) in padded.iter_mut().zip(k2.iter()) {
             *p ^= k;
         }


### PR DESCRIPTION
Based on discussions in a [separate](https://github.com/rust-embedded/msp430-quickstart/issues/4) repo, I thought it would be fun to add size optimizations to this crate.

## Benchmarks

Test code:

```rust
#![no_main]
#![no_std]
#![feature(abi_msp430_interrupt)]

extern crate panic_msp430;

use msp430::asm;
use msp430_rt::entry;
use msp430f5529::interrupt;
use hmac_sha256::HMAC;

// P0 = red LED
// P6 = green LED
#[entry]
fn main() -> ! {
    let p = msp430f5529::Peripherals::take().unwrap();

    // Disable watchdog
    let wd = p.WATCHDOG_TIMER;
    wd.wdtctl.write(|w| {
        unsafe { w.bits(0x5A00) } // password
        .wdthold().set_bit()
    });

    let p12 = p.PORT_1_2;
    let p34 = p.PORT_3_4;

    p12.p1dir
       .modify(|_, w| w.p1dir0().set_bit());
    p12.p1out
       .modify(|_, w| w.p1out0().set_bit());
    p12.p1out
       .modify(|_, w| w.p1out0().clear_bit());

    let h = HMAC::mac(&[], &[0u8; 32]);
    assert_eq!(
        &h[..],
        &[
            182, 19, 103, 154, 8, 20, 217, 236, 119, 47, 149, 215, 120, 195, 95, 197, 255, 22, 151,
            196, 147, 113, 86, 83, 198, 199, 18, 20, 66, 146, 197, 173
        ]
    );

    p12.p1out
       .modify(|_, w| w.p1out0().set_bit());

    loop {
        asm::nop();
    }
}


#[interrupt]
fn TIMER0_A0() {

}
```

With `opt_size` disabled (msp430), it takes ~155ms to get to the infinite loop:
![image](https://user-images.githubusercontent.com/6418027/112190559-7dd2d580-8bdb-11eb-8d10-e96efd87dbd5.png)

Crate size is reasonable:

```
$ msp430-elf-size target/msp430-none-elf/release/examples/blinky
   text    data     bss     dec     hex filename
  17970       0       2   17972    4634 target/msp430-none-elf/release/examples/blinky
```


With `opt_size` enabled (msp430), it takes ~180ms to get to the infinite loop:
![image](https://user-images.githubusercontent.com/6418027/112190877-ce4a3300-8bdb-11eb-8d6a-799363f5db69.png)

The crate size drops drastically:

```
$ msp430-elf-size target/msp430-none-elf/release/examples/blinky
   text    data     bss     dec     hex filename
   4418       0       2    4420    1144 target/msp430-none-elf/release/examples/blinky
```
